### PR TITLE
November 2023 updates

### DIFF
--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -1733,7 +1733,7 @@ Resources:
       cfn-lint:
         config:
           ignore_checks:
-            - EIAMPolicyActionWildcard 
+            - EIAMPolicyActionWildcard
             - EPolicyWildcardPrincipal
           ignore_reasons: 
             - EIAMPolicyActionWildcard: Wildcard should not be used for Action in IAM policies. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead.

--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -1736,8 +1736,8 @@ Resources:
             - EIAMPolicyActionWildcard 
             - EPolicyWildcardPrincipal
           ignore_reasons: 
-            EIAMPolicyActionWildcard: "Wildcard should not be used for Action in IAM policies. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
-            EPolicyWildcardPrincipal: "Policy should not allow * Principal. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
+            - EIAMPolicyActionWildcard: Wildcard should not be used for Action in IAM policies. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead.
+            - EPolicyWildcardPrincipal: Policy should not allow * Principal. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead.
     Properties:
       PolicyDocument:
         Version: '2012-10-17'

--- a/templates/aws-vpc.template.yaml
+++ b/templates/aws-vpc.template.yaml
@@ -1733,10 +1733,11 @@ Resources:
       cfn-lint:
         config:
           ignore_checks:
-            - id: EIAMPolicyActionWildcard
-              reason: "Wildcard should not be used for Action in IAM policies. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
-            - id: EPolicyWildcardPrincipal
-              reason: "Policy should not allow * Principal. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
+            - EIAMPolicyActionWildcard 
+            - EPolicyWildcardPrincipal
+          ignore_reasons: 
+            EIAMPolicyActionWildcard: "Wildcard should not be used for Action in IAM policies. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
+            EPolicyWildcardPrincipal: "Policy should not allow * Principal. Ignored as we don't want to disable other customer S3 usage from resources created inside this VPC. Apply IAM rules to limit resource access instead."
     Properties:
       PolicyDocument:
         Version: '2012-10-17'

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -1332,11 +1332,12 @@ Resources:
                 - "ssm:GetParameter"
                 - "ssm:GetParameters"
               Resource:
-                - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${VsensorUpdatekey}"
-                - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstanceHostname}"
-                - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstancePushtoken}"
-                - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstanceProxy}"
-                - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${osSensorHMAC}"
+                # Remove double slashes causes by SSM parameter names containing a leading slash
+                - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${VsensorUpdatekey}"]]
+                - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstanceHostname}"]]
+                - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstancePushtoken}"]]
+                - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstanceProxy}"]]
+                - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${osSensorHMAC}"]]
         - PolicyName: "AllowEncryptedCloudWatchLogging"
           PolicyDocument:
             Statement:

--- a/templates/darktrace-vsensor-workload.template.yaml
+++ b/templates/darktrace-vsensor-workload.template.yaml
@@ -1332,7 +1332,7 @@ Resources:
                 - "ssm:GetParameter"
                 - "ssm:GetParameters"
               Resource:
-                # Remove double slashes causes by SSM parameter names containing a leading slash
+                # Remove double slashes caused by SSM parameter names containing a leading slash
                 - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${VsensorUpdatekey}"]]
                 - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstanceHostname}"]]
                 - !Join ["/", !Split ["//", !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${DarktraceInstancePushtoken}"]]


### PR DESCRIPTION
* Make cross zone load balancing off by default (to save traffic mirroring costs) by allowing configuration of upto 6 Availability Zones for largest AWS region.
* Allow PCAP storage to be disabled by setting the PCAP storage lifetime to 0.
* Improve parameter descriptions.
* Fix some issues with the template migration using the Quickstart public bucket name